### PR TITLE
Customize nodegroup instance types and counts in Tike PROD and JWebbinar DEV

### DIFF
--- a/inventories/group_vars/all/vars.yml
+++ b/inventories/group_vars/all/vars.yml
@@ -9,3 +9,8 @@ tf_dir: /home/ec2-user/terraform-deploy
 # This is the max size of the user data EFS volume (bytes)
 # 10995116277760 = 10 TB
 efs_threshold_bytes: 10995116277760
+
+notebook_instance_type: r5.xlarge
+notebook_min_capacity: 1
+notebook_desired_capacity: 1
+notebook_max_capacity: 10

--- a/inventories/group_vars/jwebbinar-dev/vars.yml
+++ b/inventories/group_vars/jwebbinar-dev/vars.yml
@@ -1,0 +1,1 @@
+notebook_instance_type: r5.2xlarge

--- a/inventories/group_vars/tike-prod/vars.yml
+++ b/inventories/group_vars/tike-prod/vars.yml
@@ -1,0 +1,4 @@
+notebook_instance_type: r5.xlarge
+notebook_min_capacity: 1
+notebook_desired_capacity: 1
+notebook_max_capacity: 50

--- a/templates/terraform/ephemeral.tfvars.j2
+++ b/templates/terraform/ephemeral.tfvars.j2
@@ -20,3 +20,8 @@ private_subnet_names = ["{{ env|upper }}-{{ cluster_name|upper }}-SC-DMZ-*"]
 # Assign your CI-node to jupyerhub-cluster-sg before running Terraform.
 cluster_sg_name = "jupyterhub-cluster-sg"
 worker_sg_name = "jupyterhub-worker-sg"
+
+notebook_instance_type: "{{ notebook_instance_type }}"
+notebook_min_capacity: {{ notebook_min_capacity }}
+notebook_desired_capacity: {{ notebook_desired_capacity }}
+notebook_max_capacity: {{ notebook_max_capacity }}


### PR DESCRIPTION
Draft changes to set Tike PROD nodegroup min, max, desired counts to custom values.
Also set jwebbinar instance type to r5.2xlarge.